### PR TITLE
Issue #171 Fix src/library/colorizer tests

### DIFF
--- a/library/cpp/colorizer/CMakeLists.txt
+++ b/library/cpp/colorizer/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (YDB_SDK_TESTS)
+  add_subdirectory(ut)
+endif()
+
 _ydb_sdk_add_library(colorizer)
 
 target_link_libraries(colorizer PUBLIC

--- a/library/cpp/colorizer/ut/CMakeLists.txt
+++ b/library/cpp/colorizer/ut/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_ydb_test(NAME colorizer-ut
+  SOURCES
+    colorizer_ut.cpp
+  LINK_LIBRARIES
+    colorizer
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)


### PR DESCRIPTION
**Issue #171**

В `colors.h` добавил объявление оператора << для `NColorizer::EAnsiCode`, так как без него вызывался оператор << для `char` (underlying тип енума кастился в `char` по всей видимости).