### PR TITLE
[Not for merging] Fixes for library unit tests with gtest

### DIFF
--- a/library/cpp/iterator/CMakeLists.txt
+++ b/library/cpp/iterator/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (YDB_SDK_TESTS)
+  add_subdirectory(ut)
+endif()
+
 _ydb_sdk_add_library(iterator)
 
 target_link_libraries(iterator PUBLIC

--- a/library/cpp/iterator/ut/CMakeLists.txt
+++ b/library/cpp/iterator/ut/CMakeLists.txt
@@ -4,6 +4,7 @@ add_ydb_test(NAME iterator-filtering_ut GTEST
   LINK_LIBRARIES
     iterator
     GTest::gtest_main
+    GTest::gmock
   LABELS
     unit
 )
@@ -14,6 +15,7 @@ add_ydb_test(NAME iterator-functools_ut GTEST
   LINK_LIBRARIES
     iterator
     GTest::gtest_main
+    GTest::gmock
   LABELS
     unit
 )
@@ -24,6 +26,7 @@ add_ydb_test(NAME iterator-iterate_keys_ut GTEST
   LINK_LIBRARIES
     iterator
     GTest::gtest_main
+    GTest::gmock
   LABELS
     unit
 )
@@ -34,6 +37,7 @@ add_ydb_test(NAME iterator-iterate_values_ut GTEST
   LINK_LIBRARIES
     iterator
     GTest::gtest_main
+    GTest::gmock
   LABELS
     unit
 )
@@ -44,6 +48,7 @@ add_ydb_test(NAME iterator-mapped_ut GTEST
   LINK_LIBRARIES
     iterator
     GTest::gtest_main
+    GTest::gmock
   LABELS
     unit
 )

--- a/library/cpp/iterator/ut/CMakeLists.txt
+++ b/library/cpp/iterator/ut/CMakeLists.txt
@@ -1,0 +1,59 @@
+add_ydb_test(NAME iterator-filtering_ut GTEST
+  SOURCES
+    filtering_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME iterator-functools_ut GTEST
+  SOURCES
+    functools_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME iterator-iterate_keys_ut GTEST
+  SOURCES
+    iterate_keys_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME iterator-iterate_values_ut GTEST
+  SOURCES
+    iterate_values_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME iterator-mapped_ut GTEST
+  SOURCES
+    mapped_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME iterator-zip_ut GTEST
+  SOURCES
+    zip_ut.cpp
+  LINK_LIBRARIES
+    iterator
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/iterator/ut/filtering_ut.cpp
+++ b/library/cpp/iterator/ut/filtering_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/iterator/filtering.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <util/generic/vector.h>
 

--- a/library/cpp/iterator/ut/functools_ut.cpp
+++ b/library/cpp/iterator/ut/functools_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/iterator/functools.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <util/generic/vector.h>
 #include <util/generic/xrange.h>

--- a/library/cpp/iterator/ut/iterate_keys_ut.cpp
+++ b/library/cpp/iterator/ut/iterate_keys_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/iterator/iterate_keys.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <map>
 

--- a/library/cpp/iterator/ut/iterate_values_ut.cpp
+++ b/library/cpp/iterator/ut/iterate_values_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/iterator/iterate_values.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <util/generic/algorithm.h>
 

--- a/library/cpp/iterator/ut/mapped_ut.cpp
+++ b/library/cpp/iterator/ut/mapped_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/iterator/mapped.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <util/generic/map.h>
 #include <util/generic/vector.h>

--- a/library/cpp/iterator/ut/zip_ut.cpp
+++ b/library/cpp/iterator/ut/zip_ut.cpp
@@ -1,6 +1,6 @@
 #include <library/cpp/iterator/zip.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <util/generic/vector.h>
 
@@ -25,4 +25,3 @@ TEST(TIterator, ZipSimplePostIncrement) {
 
     EXPECT_EQ(std::next(cur), last);
 }
-

--- a/library/cpp/yson/CMakeLists.txt
+++ b/library/cpp/yson/CMakeLists.txt
@@ -1,13 +1,17 @@
+if (YDB_SDK_TESTS)
+  add_subdirectory(ut)
+endif()
+
 _ydb_sdk_add_library(yson)
 
-target_link_libraries(yson 
+target_link_libraries(yson
   PUBLIC
     yutil
     yt-misc
     yt-yson
 )
 
-target_sources(yson 
+target_sources(yson
   PRIVATE
     consumer.cpp
     lexer.cpp

--- a/library/cpp/yson/ut/CMakeLists.txt
+++ b/library/cpp/yson/ut/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_ydb_test(NAME yson-ut GTEST
+  SOURCES
+    yson_ut.cpp
+  LINK_LIBRARIES
+    yson
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/yson/ut/yson_ut.cpp
+++ b/library/cpp/yson/ut/yson_ut.cpp
@@ -1,7 +1,7 @@
 #include <library/cpp/yson/parser.h>
 #include <library/cpp/yson/writer.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <util/stream/mem.h>
 

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (YDB_SDK_TESTS)
   add_subdirectory(coding/unittests)
+  add_subdirectory(containers/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -2,6 +2,7 @@ if (YDB_SDK_TESTS)
   add_subdirectory(coding/unittests)
   add_subdirectory(containers/unittests)
   add_subdirectory(memory/unittests)
+  add_subdirectory(misc/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -4,6 +4,7 @@ if (YDB_SDK_TESTS)
   add_subdirectory(memory/unittests)
   add_subdirectory(misc/unittests)
   add_subdirectory(small_containers/unittests)
+  add_subdirectory(string/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)
@@ -147,6 +148,7 @@ target_sources(yt-string
     string/guid.cpp
     string/string.cpp
     string/format.cpp
+    string/format_string.cpp
 )
 _ydb_sdk_install_targets(TARGETS yt-string)
 

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (YDB_SDK_TESTS)
+  add_subdirectory(coding/unittests)
+endif()
+
 _ydb_sdk_add_library(yt-assert)
 target_compile_options(yt-assert PRIVATE
   -Wdeprecated-this-capture
@@ -33,8 +37,11 @@ _ydb_sdk_add_library(yt-exception)
 target_compile_options(yt-exception PRIVATE
   -Wdeprecated-this-capture
 )
-target_link_libraries(yt-exception PUBLIC
-  yutil
+target_link_libraries(yt-exception
+  PUBLIC
+    yutil
+  PRIVATE
+    yt-assert
 )
 target_sources(yt-exception PRIVATE
   exception/exception.cpp
@@ -107,7 +114,7 @@ _ydb_sdk_install_targets(TARGETS yt-misc)
 
 
 _ydb_sdk_add_library(yt-small_containers INTERFACE)
-target_link_libraries(yt-small_containers 
+target_link_libraries(yt-small_containers
   INTERFACE
     yutil
     yt-assert
@@ -121,7 +128,7 @@ _ydb_sdk_add_library(yt-string)
 target_compile_options(yt-string PRIVATE
   -Wdeprecated-this-capture
 )
-target_link_libraries(yt-string 
+target_link_libraries(yt-string
   PUBLIC
     yutil
     yt-assert

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -5,6 +5,7 @@ if (YDB_SDK_TESTS)
   add_subdirectory(misc/unittests)
   add_subdirectory(small_containers/unittests)
   add_subdirectory(string/unittests)
+  add_subdirectory(yson_string/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -1,6 +1,7 @@
 if (YDB_SDK_TESTS)
   add_subdirectory(coding/unittests)
   add_subdirectory(containers/unittests)
+  add_subdirectory(memory/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -3,6 +3,7 @@ if (YDB_SDK_TESTS)
   add_subdirectory(containers/unittests)
   add_subdirectory(memory/unittests)
   add_subdirectory(misc/unittests)
+  add_subdirectory(small_containers/unittests)
 endif()
 
 _ydb_sdk_add_library(yt-assert)

--- a/library/cpp/yt/coding/unittests/CMakeLists.txt
+++ b/library/cpp/yt/coding/unittests/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_ydb_test(NAME yt-coding-varint_ut GTEST
+  SOURCES
+    varint_ut.cpp
+  LINK_LIBRARIES
+    yt-coding
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-coding-zig_zag_ut GTEST
+  SOURCES
+    zig_zag_ut.cpp
+  LINK_LIBRARIES
+    yt-coding
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/yt/coding/unittests/varint_ut.cpp
+++ b/library/cpp/yt/coding/unittests/varint_ut.cpp
@@ -1,8 +1,10 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/coding/varint.h>
 
 #include <util/random/random.h>
+
+#include <util/stream/str.h>
 
 #include <util/string/escape.h>
 

--- a/library/cpp/yt/coding/unittests/zig_zag_ut.cpp
+++ b/library/cpp/yt/coding/unittests/zig_zag_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/coding/zig_zag.h>
 

--- a/library/cpp/yt/containers/unittests/CMakeLists.txt
+++ b/library/cpp/yt/containers/unittests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_ydb_test(NAME yt-containers-enum_indexed_array_ut GTEST
     enum_indexed_array_ut.cpp
   LINK_LIBRARIES
     yt-containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit
@@ -13,6 +14,7 @@ add_ydb_test(NAME yt-containers-sharded_set_ut GTEST
     sharded_set_ut.cpp
   LINK_LIBRARIES
     yt-containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit

--- a/library/cpp/yt/containers/unittests/CMakeLists.txt
+++ b/library/cpp/yt/containers/unittests/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_ydb_test(NAME yt-containers-enum_indexed_array_ut GTEST
+  SOURCES
+    enum_indexed_array_ut.cpp
+  LINK_LIBRARIES
+    yt-containers
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-containers-sharded_set_ut GTEST
+  SOURCES
+    sharded_set_ut.cpp
+  LINK_LIBRARIES
+    yt-containers
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/yt/containers/unittests/enum_indexed_array_ut.cpp
+++ b/library/cpp/yt/containers/unittests/enum_indexed_array_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/containers/enum_indexed_array.h>
 
@@ -42,4 +42,3 @@ TEST(TEnumIndexedArrayTest, Simple)
 
 } // namespace
 } // namespace NYT
-

--- a/library/cpp/yt/containers/unittests/sharded_set_ut.cpp
+++ b/library/cpp/yt/containers/unittests/sharded_set_ut.cpp
@@ -1,6 +1,6 @@
 #include <library/cpp/yt/containers/sharded_set.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <random>
 

--- a/library/cpp/yt/memory/unittests/CMakeLists.txt
+++ b/library/cpp/yt/memory/unittests/CMakeLists.txt
@@ -1,0 +1,123 @@
+add_ydb_test(NAME yt-memory-atomic_intrusive_ptr_ut GTEST
+  SOURCES
+    atomic_intrusive_ptr_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+    GTest::gmock
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-chunked_memory_pool_allocator_ut GTEST
+  SOURCES
+    chunked_memory_pool_allocator_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-chunked_memory_pool_output_ut GTEST
+  SOURCES
+    chunked_memory_pool_output_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-chunked_memory_pool_ut GTEST
+  SOURCES
+    chunked_memory_pool_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+#[=[
+TODO: missing the library `library/cpp/int128`
+add_ydb_test(NAME yt-memory-erased_storage_ut GTEST
+  SOURCES
+    erased_storage_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+#]=]
+add_ydb_test(NAME yt-memory-free_list_ut GTEST
+  SOURCES
+    free_list_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-function_view_ut GTEST
+  SOURCES
+    function_view_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-intrusive_ptr_ut GTEST
+  SOURCES
+    intrusive_ptr_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+    GTest::gmock
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-ref_ut GTEST
+  SOURCES
+    ref_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-safe_memory_reader_ut GTEST
+  SOURCES
+    safe_memory_reader_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-shared_range_ut GTEST
+  SOURCES
+    shared_range_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-memory-weak_ptr_ut GTEST
+  SOURCES
+    weak_ptr_ut.cpp
+  LINK_LIBRARIES
+    yt-memory
+    GTest::gtest_main
+    GTest::gmock
+  LABELS
+    unit
+)

--- a/library/cpp/yt/memory/unittests/CMakeLists.txt
+++ b/library/cpp/yt/memory/unittests/CMakeLists.txt
@@ -38,18 +38,18 @@ add_ydb_test(NAME yt-memory-chunked_memory_pool_ut GTEST
   LABELS
     unit
 )
-#[=[
-TODO: missing the library `library/cpp/int128`
+
 add_ydb_test(NAME yt-memory-erased_storage_ut GTEST
   SOURCES
     erased_storage_ut.cpp
   LINK_LIBRARIES
     yt-memory
+    int128
     GTest::gtest_main
   LABELS
     unit
 )
-#]=]
+
 add_ydb_test(NAME yt-memory-free_list_ut GTEST
   SOURCES
     free_list_ut.cpp

--- a/library/cpp/yt/memory/unittests/atomic_intrusive_ptr_ut.cpp
+++ b/library/cpp/yt/memory/unittests/atomic_intrusive_ptr_ut.cpp
@@ -1,4 +1,5 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <library/cpp/yt/memory/new.h>
 #include <library/cpp/yt/memory/ref_counted.h>

--- a/library/cpp/yt/memory/unittests/chunked_memory_pool_allocator_ut.cpp
+++ b/library/cpp/yt/memory/unittests/chunked_memory_pool_allocator_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/chunked_memory_pool.h>
 #include <library/cpp/yt/memory/chunked_memory_pool_allocator.h>

--- a/library/cpp/yt/memory/unittests/chunked_memory_pool_output_ut.cpp
+++ b/library/cpp/yt/memory/unittests/chunked_memory_pool_output_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/chunked_memory_pool.h>
 #include <library/cpp/yt/memory/chunked_memory_pool_output.h>

--- a/library/cpp/yt/memory/unittests/chunked_memory_pool_ut.cpp
+++ b/library/cpp/yt/memory/unittests/chunked_memory_pool_ut.cpp
@@ -1,6 +1,6 @@
 #include <util/string/cast.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/chunked_memory_pool.h>
 

--- a/library/cpp/yt/memory/unittests/erased_storage_ut.cpp
+++ b/library/cpp/yt/memory/unittests/erased_storage_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/erased_storage.h>
 

--- a/library/cpp/yt/memory/unittests/free_list_ut.cpp
+++ b/library/cpp/yt/memory/unittests/free_list_ut.cpp
@@ -1,6 +1,8 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/free_list.h>
+
+#include <util/datetime/base.h>
 
 #include <util/random/random.h>
 

--- a/library/cpp/yt/memory/unittests/function_view_ut.cpp
+++ b/library/cpp/yt/memory/unittests/function_view_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/function_view.h>
 

--- a/library/cpp/yt/memory/unittests/intrusive_ptr_ut.cpp
+++ b/library/cpp/yt/memory/unittests/intrusive_ptr_ut.cpp
@@ -1,4 +1,5 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <library/cpp/yt/memory/new.h>
 #include <library/cpp/yt/memory/ref_counted.h>
@@ -7,6 +8,7 @@
 #include <util/generic/buffer.h>
 
 #include <util/stream/buffer.h>
+#include <util/stream/str.h>
 
 #include <util/ysaveload.h>
 

--- a/library/cpp/yt/memory/unittests/ref_ut.cpp
+++ b/library/cpp/yt/memory/unittests/ref_ut.cpp
@@ -1,6 +1,5 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
-#include <library/cpp/testing/gtest_extensions/assertions.h>
 
 #include <library/cpp/yt/memory/ref.h>
 

--- a/library/cpp/yt/memory/unittests/safe_memory_reader_ut.cpp
+++ b/library/cpp/yt/memory/unittests/safe_memory_reader_ut.cpp
@@ -1,5 +1,5 @@
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/safe_memory_reader.h>
 

--- a/library/cpp/yt/memory/unittests/shared_range_ut.cpp
+++ b/library/cpp/yt/memory/unittests/shared_range_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/memory/new.h>
 #include <library/cpp/yt/memory/shared_range.h>

--- a/library/cpp/yt/memory/unittests/weak_ptr_ut.cpp
+++ b/library/cpp/yt/memory/unittests/weak_ptr_ut.cpp
@@ -1,4 +1,5 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <library/cpp/yt/memory/new.h>
 #include <library/cpp/yt/memory/weak_ptr.h>

--- a/library/cpp/yt/misc/unittests/CMakeLists.txt
+++ b/library/cpp/yt/misc/unittests/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_ydb_test(NAME yt-misc-enum_ut GTEST
+  SOURCES
+    enum_ut.cpp
+  LINK_LIBRARIES
+    yt-misc
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-misc-guid_ut GTEST
+  SOURCES
+    guid_ut.cpp
+  LINK_LIBRARIES
+    yt-misc
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-misc-preprocessor_ut GTEST
+  SOURCES
+    preprocessor_ut.cpp
+  LINK_LIBRARIES
+    yt-misc
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-misc-strong_typedef_ut GTEST
+  SOURCES
+    strong_typedef_ut.cpp
+  LINK_LIBRARIES
+    yt-misc
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/yt/misc/unittests/enum_ut.cpp
+++ b/library/cpp/yt/misc/unittests/enum_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/misc/cast.h>
 #include <library/cpp/yt/misc/enum.h>
@@ -284,4 +284,3 @@ TEST(TEnumTest, Cast)
 
 } // namespace
 } // namespace NYT
-

--- a/library/cpp/yt/misc/unittests/guid_ut.cpp
+++ b/library/cpp/yt/misc/unittests/guid_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/misc/guid.h>
 

--- a/library/cpp/yt/misc/unittests/preprocessor_ut.cpp
+++ b/library/cpp/yt/misc/unittests/preprocessor_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/misc/preprocessor.h>
 

--- a/library/cpp/yt/small_containers/unittests/CMakeLists.txt
+++ b/library/cpp/yt/small_containers/unittests/CMakeLists.txt
@@ -1,0 +1,50 @@
+add_ydb_test(NAME yt-small_containers-compact_flat_map_ut GTEST
+  SOURCES
+    compact_flat_map_ut.cpp
+  LINK_LIBRARIES
+    yt-small_containers
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-small_containers-compact_heap_ut GTEST
+  SOURCES
+    compact_heap_ut.cpp
+  LINK_LIBRARIES
+    yt-small_containers
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-small_containers-compact_queue_ut GTEST
+  SOURCES
+    compact_queue_ut.cpp
+  LINK_LIBRARIES
+    yt-small_containers
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-small_containers-compact_set_ut GTEST
+  SOURCES
+    compact_set_ut.cpp
+  LINK_LIBRARIES
+    yt-small_containers
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-small_containers-compact_vector_ut GTEST
+  SOURCES
+    compact_vector_ut.cpp
+  LINK_LIBRARIES
+    yt-small_containers
+    GTest::gtest_main
+    GTest::gmock
+  LABELS
+    unit
+)

--- a/library/cpp/yt/small_containers/unittests/CMakeLists.txt
+++ b/library/cpp/yt/small_containers/unittests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_ydb_test(NAME yt-small_containers-compact_flat_map_ut GTEST
     compact_flat_map_ut.cpp
   LINK_LIBRARIES
     yt-small_containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit
@@ -13,6 +14,7 @@ add_ydb_test(NAME yt-small_containers-compact_heap_ut GTEST
     compact_heap_ut.cpp
   LINK_LIBRARIES
     yt-small_containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit
@@ -23,6 +25,7 @@ add_ydb_test(NAME yt-small_containers-compact_queue_ut GTEST
     compact_queue_ut.cpp
   LINK_LIBRARIES
     yt-small_containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit
@@ -33,6 +36,7 @@ add_ydb_test(NAME yt-small_containers-compact_set_ut GTEST
     compact_set_ut.cpp
   LINK_LIBRARIES
     yt-small_containers
+    yt-string
     GTest::gtest_main
   LABELS
     unit
@@ -43,6 +47,7 @@ add_ydb_test(NAME yt-small_containers-compact_vector_ut GTEST
     compact_vector_ut.cpp
   LINK_LIBRARIES
     yt-small_containers
+    yt-string
     GTest::gtest_main
     GTest::gmock
   LABELS

--- a/library/cpp/yt/small_containers/unittests/compact_flat_map_ut.cpp
+++ b/library/cpp/yt/small_containers/unittests/compact_flat_map_ut.cpp
@@ -1,6 +1,6 @@
 #include <library/cpp/yt/small_containers/compact_flat_map.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <string>
 #include <vector>

--- a/library/cpp/yt/small_containers/unittests/compact_heap_ut.cpp
+++ b/library/cpp/yt/small_containers/unittests/compact_heap_ut.cpp
@@ -1,6 +1,6 @@
 #include <library/cpp/yt/small_containers/compact_heap.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <random>
 

--- a/library/cpp/yt/small_containers/unittests/compact_queue_ut.cpp
+++ b/library/cpp/yt/small_containers/unittests/compact_queue_ut.cpp
@@ -1,6 +1,6 @@
 #include <library/cpp/yt/small_containers/compact_queue.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <queue>
 #include <random>

--- a/library/cpp/yt/small_containers/unittests/compact_set_ut.cpp
+++ b/library/cpp/yt/small_containers/unittests/compact_set_ut.cpp
@@ -12,7 +12,7 @@
 
 #include <library/cpp/yt/small_containers/compact_set.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <string>
 

--- a/library/cpp/yt/small_containers/unittests/compact_vector_ut.cpp
+++ b/library/cpp/yt/small_containers/unittests/compact_vector_ut.cpp
@@ -14,7 +14,8 @@
 
 #include <library/cpp/yt/small_containers/compact_vector.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <util/string/cast.h>
 

--- a/library/cpp/yt/string/format-inl.h
+++ b/library/cpp/yt/string/format-inl.h
@@ -126,7 +126,7 @@ inline TString TStringBuilder::Flush()
 
 inline void TStringBuilder::DoReset()
 {
-    Buffer_ = {};
+    Buffer_ = TString{};
 }
 
 inline void TStringBuilder::DoReserve(size_t newLength)

--- a/library/cpp/yt/string/unittests/CMakeLists.txt
+++ b/library/cpp/yt/string/unittests/CMakeLists.txt
@@ -1,40 +1,37 @@
-add_ydb_test(NAME yt-misc-enum_ut GTEST
+add_ydb_test(NAME yt-string-enum_ut GTEST
   SOURCES
     enum_ut.cpp
   LINK_LIBRARIES
-    yt-misc
+    yt-string
     GTest::gtest_main
   LABELS
     unit
 )
 
-add_ydb_test(NAME yt-misc-guid_ut GTEST
+add_ydb_test(NAME yt-string-format_ut GTEST
+  SOURCES
+    format_ut.cpp
+  LINK_LIBRARIES
+    yt-string
+    GTest::gtest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME yt-string-guid_ut GTEST
   SOURCES
     guid_ut.cpp
   LINK_LIBRARIES
-    yt-misc
     yt-string
     GTest::gtest_main
   LABELS
     unit
 )
 
-add_ydb_test(NAME yt-misc-preprocessor_ut GTEST
+add_ydb_test(NAME yt-string-string_ut GTEST
   SOURCES
-    preprocessor_ut.cpp
+    string_ut.cpp
   LINK_LIBRARIES
-    yt-misc
-    yt-string
-    GTest::gtest_main
-  LABELS
-    unit
-)
-
-add_ydb_test(NAME yt-misc-strong_typedef_ut GTEST
-  SOURCES
-    strong_typedef_ut.cpp
-  LINK_LIBRARIES
-    yt-misc
     yt-string
     GTest::gtest_main
   LABELS

--- a/library/cpp/yt/string/unittests/enum_ut.cpp
+++ b/library/cpp/yt/string/unittests/enum_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/string/enum.h>
 #include <library/cpp/yt/string/format.h>
@@ -84,5 +84,3 @@ TEST(TParseEnumTest, ParseBitEnum)
 
 } // namespace
 } // namespace NYT
-
-

--- a/library/cpp/yt/string/unittests/format_ut.cpp
+++ b/library/cpp/yt/string/unittests/format_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/string/format.h>
 

--- a/library/cpp/yt/string/unittests/guid_ut.cpp
+++ b/library/cpp/yt/string/unittests/guid_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/string/guid.h>
 #include <library/cpp/yt/string/format.h>

--- a/library/cpp/yt/string/unittests/string_ut.cpp
+++ b/library/cpp/yt/string/unittests/string_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/string/string.h>
 
@@ -49,4 +49,3 @@ TEST(TStringTest, CamelCaseToUnderscoreCase)
 
 } // namespace
 } // namespace NYT
-

--- a/library/cpp/yt/yson_string/unittests/CMakeLists.txt
+++ b/library/cpp/yt/yson_string/unittests/CMakeLists.txt
@@ -1,0 +1,21 @@
+#[=[
+TODO: missing `library/cpp/testing/gtest_extensions`
+add_ydb_test(NAME yt-yson_string-convert_ut GTEST
+  SOURCES
+    convert_ut.cpp
+  LINK_LIBRARIES
+    yt-yson_string
+    GTest::gtest_main
+  LABELS
+    unit
+)
+#]=]
+add_ydb_test(NAME yt-yson_string-saveload_ut GTEST
+  SOURCES
+    saveload_ut.cpp
+  LINK_LIBRARIES
+    yt-yson_string
+    GTest::gtest_main
+  LABELS
+    unit
+)

--- a/library/cpp/yt/yson_string/unittests/convert_ut.cpp
+++ b/library/cpp/yt/yson_string/unittests/convert_ut.cpp
@@ -1,4 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/testing/gtest_extensions/assertions.h>
 

--- a/library/cpp/yt/yson_string/unittests/saveload_ut.cpp
+++ b/library/cpp/yt/yson_string/unittests/saveload_ut.cpp
@@ -1,6 +1,4 @@
-#include <library/cpp/testing/gtest/gtest.h>
-
-#include <library/cpp/testing/gtest_extensions/assertions.h>
+#include <gtest/gtest.h>
 
 #include <library/cpp/yt/yson_string/string.h>
 


### PR DESCRIPTION
Часть коммитов здесь затрагивает только CMake файлы, а самые последние коммиты – это с изменениями в `library` – скорее иллюстрация, как я предлагаю решить проблему. Перед финальным мёржем эти изменения собираюсь откатить.

Здесь все юнит-тесты из `library`, которые зависят от `library/cpp/testing/gtest`, а именно:
- #189 
- #209 
- #210 

Я видел, что в тестах для `library/cpp/coroutine/engine/stack` эту зависимость поменяли: и теперь те юнит-тесты зависят напрямую от гугл-тест библиотеки, без прослойки `library/cpp/testing/gtest`. Здесь я предлагаю поступить так же, заменив инклюды `#include <library/cpp/testing/gtest/gtest.h>` на `#include <gtest/gtest.h>` и, где необходимо, `#include <gmock/gmock.h>`. Если неприемлемо, тогда нужно вернуть `library/cpp/testing/gtest` и `library/cpp/testing/gtest_main`.

Теперь к другим деталям:
- В некоторых тестах добавил недостающие инклюды — это потребовалось после удаления инкдюда хедера из `library/cpp/testing/gtest`.
- В [library/cpp/yt/memory](https://github.com/ydb-platform/ydb-cpp-sdk/pull/292/files#diff-a25f6e51ebefb0415f324fee9c39dabd35d6eb82b152400d250ebf7fdcf12fa7) пока что закомментировал тест `erased_storage_ut`, потому что он требует недостающей библиотеки `library/cpp/int128`. Её нужно либо притащить, либо через макросы убрать часть тестов.
- В [library/cpp/yt/yson_string](https://github.com/ydb-platform/ydb-cpp-sdk/pull/292/files#diff-cb693c17742b830b4c237ee4d530259b353970066b7a8dca74c43bcab17622b7) пока что закомментировал тест `saveload_ut`, потому что он требует недостающей библиотеки `library/cpp/testing/gtest_extensions`. У него только зависимость от макроса `EXPECT_THROW_MESSAGE_HAS_SUBSTR`. Наверное, лучше притащить эту либу, если не хотим переписывать тесты. Была ещё пара юнит тестов ([раз](https://github.com/ydb-platform/ydb-cpp-sdk/pull/292/files#diff-fa8de7091f98791b44768369b871d9a4292fd39e75de717db3f543b019ad6720) и [два](https://github.com/ydb-platform/ydb-cpp-sdk/pull/292/files#diff-1ed289c71e7b7be5ce5a80d1a93b1bfe44376b8ef98b1028a5e8b1effa5c0a50)), в которых были инклюды хедера из этой либы, но макросы из хедера не использовались, поэтому я эти инклюды убрал.
- Падал тест `library/cpp/yt/string/unittests/enum_ut.cpp`, а именно, `TFormatTest::Enum`. Там просто тестировалась формат-функция, но в процессе `TString` присваивался пустой `std::initializer_list`, всё это попадало в `std::string::assign(const char*, size_t)`, где уже грохалось в попытке разыменовать `nullptr`. Кажется, что это приколы исключительно `libstdc++`, потому что, как мне представляется, `[nullptr, nullptr)` – это вполне себе валидный диапазон, и единственное требование из стандарта к `assign`, чтобы он принимал валидный диапазон. Так или иначе, в [library/cpp/yt/string/format-inl.h](https://github.com/ydb-platform/ydb-cpp-sdk/pull/292/files#diff-4ea495fbfcba62053c5b96d444717f67aa833b13e302269bd4f78767bd629725) я заменил присваивание инишиалайзер листа на пустую строку, чтобы уж точно всё работало.