### PR TITLE
Fixed bug in basic_example-it test

### DIFF
--- a/tests/integration/basic_example_it/basic_example.cpp
+++ b/tests/integration/basic_example_it/basic_example.cpp
@@ -415,7 +415,7 @@ static TStatus ExplicitTclTransaction(TSession session, const std::string& path,
 }
 
 static TStatus ScanQuerySelect(TTableClient client, const std::string& path, std::vector <TResultSet>& vectorResultSet) {    
-    std::vector<std::string> result;
+    vectorResultSet.clear();
     auto query = std::format(R"(
         --!syntax_v1
         PRAGMA TablePathPrefix("{}");


### PR DESCRIPTION
1. Убрал не использующийся вектор result
2. Добавил очистку вектора vectorResultSet, чтобы в результат выполнения запроса не попадали ResultSet'ы с прошлого ретрая