### PR TITLE
Issue #313 Fix library/cpp/int128 tests

### DIFF
--- a/library/cpp/int128/CMakeLists.txt
+++ b/library/cpp/int128/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (YDB_SDK_TESTS)
+  add_subdirectory(ut)
+endif()
+
 _ydb_sdk_add_library(int128)
 
 target_sources(int128

--- a/library/cpp/int128/ut/CMakeLists.txt
+++ b/library/cpp/int128/ut/CMakeLists.txt
@@ -1,0 +1,105 @@
+#[=[ TODO: fix bug with std::signbit
+add_ydb_test(NAME int128-int128_ut
+  SOURCES
+   int128_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+#]=]
+
+add_ydb_test(NAME int128-int128_typetraits_ut
+  SOURCES
+    int128_typetraits_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-i128_ut
+  SOURCES
+    i128_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-i128_and_intrinsic_identity_ut
+  SOURCES
+    i128_and_intrinsic_identity_ut.cpp
+    int128_ut_helpers.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-int128_via_intrinsic_ut
+  SOURCES
+    int128_via_intrinsic_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-int128_old_ut
+  SOURCES
+    int128_old_ut.cpp
+    int128_ut_helpers.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-i128_division_ut
+  SOURCES
+    i128_division_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+#[=[ TODO: fix bug with std::signbit
+add_ydb_test(NAME int128-i128_type_traits_ut
+  SOURCES
+    i128_type_traits_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+#]=]
+
+add_ydb_test(NAME int128-i128_comparison_ut
+  SOURCES
+    i128_comparison_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)
+
+add_ydb_test(NAME int128-ui128_division_ut
+  SOURCES
+    ui128_division_ut.cpp
+  LINK_LIBRARIES
+    int128
+    cpp-testing-unittest_main
+  LABELS
+    unit
+)


### PR DESCRIPTION
Issue #313

Всё работает, кроме двух тестов `int128_ut` и `i128_type_traits_ut` (пока что закомментировал), а именно, не компилируются вызовы [`std::signbit`](https://en.cppreference.com/w/cpp/numeric/math/signbit).
Возможно, у вас внутри используется libc++, тогда понятно, почему раньше не было проблем: реализация от llvm только делает проверки на `std::is_integral`, `std::is_signed` и ещё сравнивает, меньше ли число нуля. `TInteger128` всё это умеет делать.
А вот реализация `libstdc++` проверяет только свой внутренний `__is_integer`, а он специализирован для стандартных типов + расширения gcc, поэтому он отвергает `TInteger128`.

Так ли нужна здесь проверка именно `std::signbit`? По идее, хотелось бы видеть тест френдовой функции [`signbit`](https://github.com/ydb-platform/ydb-cpp-sdk/blob/5b7141a133fcb9f10e76f0b9e7e5b25b0be103c6/library/cpp/int128/int128.h#L310), а не из стандартной библиотеки.