### PR TITLE
[Not for merging] Issue #166 Fix src/library/blockcodecs tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,14 @@ cmake --build --preset release
 
 ## Test
 
-Specify a level of parallelism by passing the `-j<level>` option into the command below (e.g. `-j$(nproc)`)
+Configure and build tests:
+
+```bash
+cmake --preset release-test
+cmake --build --preset release
+```
+
+Specify a level of parallelism by passing the `-j<level>` option into the commands below (e.g. `-j$(nproc)`).
 
 Running all tests:
 

--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ ctest -j$(nproc) --preset release-integration
 Note that some tests use a legacy test library instead of GoogleTest, see `./<test_target> --help` for details. If you need to run only certain test cases, here is an alternative for `--gtest_filter` option:
 
 ```bash
-./<test_target> --filter-file -ExcludedTestSuite +IncludedTestSuite::TestName
+./<test_target> -ExcludedTestSuite +IncludedTestSuite::TestName
 ```

--- a/README.md
+++ b/README.md
@@ -143,9 +143,5 @@ ctest -j$(nproc) --preset release-integration
 Note that some tests use a legacy test library instead of GoogleTest, see `./<test_target> --help` for details. If you need to run only certain test cases, here is an alternative for `--gtest_filter` option:
 
 ```bash
-cat <<EOF | ./<test_target> --filter-file /dev/fd/0
--ExcludedTestCase
-+IncludedTestCase
-+IncludedTestCase::TestName
-EOF
+./<test_target> --filter-file -ExcludedTestSuite +IncludedTestSuite::TestName
 ```

--- a/library/cpp/blockcodecs/CMakeLists.txt
+++ b/library/cpp/blockcodecs/CMakeLists.txt
@@ -3,12 +3,18 @@ if (YDB_SDK_TESTS)
     SOURCES
       codecs_ut.cpp
     LINK_LIBRARIES
-      blockcodecs-core
+      blockcodecs
       cpp-testing-unittest_main
     LABELS
       unit
+    TEST_ARG
+      --filter-file filter.txt
   )
-endif()
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/filter.txt
+    # Exclude this test case, because we don't use zstd06
+    "-TBlockCodecsTest::TestListAllCodecs"
+  )
+endif(YDB_SDK_TESTS)
 
 _ydb_sdk_add_library(blockcodecs-core)
 target_link_libraries(blockcodecs-core

--- a/library/cpp/blockcodecs/CMakeLists.txt
+++ b/library/cpp/blockcodecs/CMakeLists.txt
@@ -1,3 +1,15 @@
+if (YDB_SDK_TESTS)
+  add_ydb_test(NAME blockcodecs-ut
+    SOURCES
+      codecs_ut.cpp
+    LINK_LIBRARIES
+      blockcodecs-core
+      cpp-testing-unittest_main
+    LABELS
+      unit
+  )
+endif()
+
 _ydb_sdk_add_library(blockcodecs-core)
 target_link_libraries(blockcodecs-core
   PUBLIC
@@ -29,7 +41,7 @@ _ydb_sdk_install_targets(TARGETS blockcodecs-codecs-brotli)
 
 _ydb_sdk_add_library(blockcodecs-codecs-bzip INTERFACE)
 add_global_library_for(blockcodecs-codecs-bzip.global blockcodecs-codecs-bzip)
-target_link_libraries(blockcodecs-codecs-bzip.global 
+target_link_libraries(blockcodecs-codecs-bzip.global
   PRIVATE
     yutil
     BZip2::BZip2
@@ -144,7 +156,7 @@ _ydb_sdk_install_targets(TARGETS blockcodecs-codecs-zstd)
 
 
 _ydb_sdk_add_library(blockcodecs)
-target_link_libraries(blockcodecs 
+target_link_libraries(blockcodecs
   PUBLIC
     yutil
     blockcodecs-core
@@ -157,7 +169,7 @@ target_link_libraries(blockcodecs
     blockcodecs-codecs-zlib
     blockcodecs-codecs-zstd
 )
-target_sources(blockcodecs 
+target_sources(blockcodecs
   PRIVATE
     codecs.cpp
     stream.cpp

--- a/library/cpp/blockcodecs/CMakeLists.txt
+++ b/library/cpp/blockcodecs/CMakeLists.txt
@@ -8,11 +8,8 @@ if (YDB_SDK_TESTS)
     LABELS
       unit
     TEST_ARG
-      --filter-file filter.txt
-  )
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/filter.txt
-    # Exclude this test case, because we don't use zstd06
-    "-TBlockCodecsTest::TestListAllCodecs"
+      # Exclude this test case, because we don't use zstd06
+      -TBlockCodecsTest::TestListAllCodecs
   )
 endif(YDB_SDK_TESTS)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -185,10 +185,7 @@ if (YDB_SDK_TESTS)
     LABELS
       unit
     TEST_ARG
-      --filter-file filter.txt
-  )
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/random/filter.txt
-    "-TestCommonRNG::TestStlCompatibility"
+      -TestCommonRNG::TestStlCompatibility
   )
 
   add_ydb_test(NAME util-stream-ut

--- a/util/generic/buffer.cpp
+++ b/util/generic/buffer.cpp
@@ -94,6 +94,7 @@ TBuffer::~TBuffer() {
 }
 
 void TBuffer::AsString(TString& s) {
-    s.assign(Data(), Size());
+    Y_ASSERT(Data() != nullptr || Size() == 0);
+    s.assign(Data() == nullptr ? "" : Data(), Size());
     Clear();
 }


### PR DESCRIPTION
Issue #166

- Из-за того, что раньше я предложил убрать zstd06 (PR #120), закономерно упал тест `TBlockCodecsTest::TestListAllCodecs`, где проверялось наличие всех кодеков, но поскольку zstd06 больше нигде не нужна, я решил, что лучше отключить тест, чем тащить её обратно.
- С запозданием понял, что тесты можно фильтровать проще, а не как я делал до этого. Поправил.
- По аналогичной причине с PR #292 падали тесты в функции `TestAllAtOnce` при вызове метода `AsString` у пустого `TBuffer`. У libstdc++ слишком консервативный `std::string::assign(const char*, size_t)` не принимает нулевые указатели в отличие от libc++. Предложил исправление. Upd: хотя, раз эта проблема появляется уже второй раз, возможно, лучше добавить проверку на нулевой указатель в `TBasicString::assign` и в тех местах в классе, где вызывается `std::basic_string::assign`?