### PR TITLE
GCC compile fix

### DIFF
--- a/cmake/global_flags.cmake
+++ b/cmake/global_flags.cmake
@@ -28,9 +28,13 @@ string(APPEND ${COMMON_C_CXX_FLAGS} "\
 ")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  # Use .init_array instead of .ctors (default for old clang versions)
-  # See: https://maskray.me/blog/2021-11-07-init-ctors-init-array
-  string(APPEND COMMON_C_CXX_FLAGS " -fuse-init-array")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Use .init_array instead of .ctors (default for old clang versions)
+    # See: https://maskray.me/blog/2021-11-07-init-ctors-init-array
+    string(APPEND COMMON_C_CXX_FLAGS " -fuse-init-array")
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    string(APPEND COMMON_C_CXX_FLAGS " -fpermissive")
+  endif()
 endif()
 
 string(APPEND COMMON_C_CXX_FLAGS " -D_FILE_OFFSET_BITS=64")
@@ -64,17 +68,22 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_C_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_C_CXX_FLAGS} \
   -Woverloaded-virtual \
-  -Wimport-preprocessor-directive-pedantic \
-  -Wno-undefined-var-template \
-  -Wno-return-std-move \
-  -Wno-defaulted-function-deleted \
   -Wno-pessimizing-move \
-  -Wno-deprecated-anon-enum-enum-conversion \
-  -Wno-deprecated-enum-enum-conversion \
   -Wno-deprecated-enum-float-conversion \
-  -Wno-ambiguous-reversed-operator \
-  -Wno-deprecated-volatile \
 ")
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_C_CXX_FLAGS} \
+    -Wimport-preprocessor-directive-pedantic \
+    -Wno-undefined-var-template \
+    -Wno-return-std-move \
+    -Wno-defaulted-function-deleted \
+    -Wno-deprecated-enum-enum-conversion \
+    -Wno-ambiguous-reversed-operator \
+    -Wno-deprecated-volatile \
+    -Wno-deprecated-anon-enum-enum-conversion \
+  ")
+endif()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i686|x86_64|AMD64)$")
   set(_ALL_X86_EXTENSIONS_DEFINES "\

--- a/contrib/libs/libc_compat/CMakeLists.txt
+++ b/contrib/libs/libc_compat/CMakeLists.txt
@@ -1,7 +1,7 @@
 _ydb_sdk_add_library(contrib-libs-libc_compat)
 
 target_compile_options(contrib-libs-libc_compat PRIVATE
-  $<IF:$<CXX_COMPILER_ID:MSVC>,,-Wno-everything>
+  $<IF:$<CXX_COMPILER_ID:Clang>,-Wno-everything,>
 )
 
 target_sources(contrib-libs-libc_compat PRIVATE

--- a/library/cpp/yt/CMakeLists.txt
+++ b/library/cpp/yt/CMakeLists.txt
@@ -1,7 +1,11 @@
 _ydb_sdk_add_library(yt-assert)
-target_compile_options(yt-assert PRIVATE
-  -Wdeprecated-this-capture
-)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(yt-assert PRIVATE
+    -Wdeprecated-this-capture
+  )
+endif()
+
 target_link_libraries(yt-assert PUBLIC
   yutil
 )
@@ -30,9 +34,12 @@ _ydb_sdk_install_targets(TARGETS yt-containers)
 
 
 _ydb_sdk_add_library(yt-exception)
-target_compile_options(yt-exception PRIVATE
-  -Wdeprecated-this-capture
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(yt-exception PRIVATE
+    -Wdeprecated-this-capture
+  )
+endif()
+
 target_link_libraries(yt-exception PUBLIC
   yutil
 )
@@ -49,7 +56,7 @@ target_link_libraries(yt-malloc PUBLIC
 target_sources(yt-malloc PRIVATE
   malloc/malloc.cpp
 )
-if (NOT (WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64"))
+if (NOT (WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64") AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(yt-malloc PRIVATE
     -Wdeprecated-this-capture
   )
@@ -79,7 +86,7 @@ target_sources(yt-memory
     memory/safe_memory_reader.cpp
     memory/shared_range.cpp
 )
-if (NOT WIN32)
+if (NOT WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(yt-memory PRIVATE
     -Wdeprecated-this-capture
   )
@@ -88,9 +95,11 @@ _ydb_sdk_install_targets(TARGETS yt-memory)
 
 
 _ydb_sdk_add_library(yt-misc)
-target_compile_options(yt-misc PRIVATE
-  -Wdeprecated-this-capture
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(yt-misc PRIVATE
+    -Wdeprecated-this-capture
+  )
+endif()
 target_link_libraries(yt-misc
   PUBLIC
     yutil
@@ -118,9 +127,11 @@ _ydb_sdk_install_targets(TARGETS yt-small_containers)
 
 
 _ydb_sdk_add_library(yt-string)
-target_compile_options(yt-string PRIVATE
-  -Wdeprecated-this-capture
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(yt-string PRIVATE
+    -Wdeprecated-this-capture
+  )
+endif()
 target_link_libraries(yt-string 
   PUBLIC
     yutil
@@ -141,9 +152,11 @@ _ydb_sdk_install_targets(TARGETS yt-string)
 
 
 _ydb_sdk_add_library(yt-yson)
-target_compile_options(yt-yson PRIVATE
-  -Wdeprecated-this-capture
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(yt-yson PRIVATE
+    -Wdeprecated-this-capture
+  )
+endif()
 target_link_libraries(yt-yson
   PUBLIC
     yutil
@@ -171,7 +184,7 @@ target_sources(yt-yson_string PRIVATE
   yson_string/convert.cpp
   yson_string/string.cpp
 )
-if (NOT (WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64"))
+if (NOT (WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64") AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(yt-yson_string PRIVATE
     -Wdeprecated-this-capture
   )

--- a/src/client/topic/impl/CMakeLists.txt
+++ b/src/client/topic/impl/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(client-ydb_topic-impl PUBLIC
   client-ydb_driver
   client-ydb_topic-common
   client-ydb_proto
-  client-ydb_topic
   client-ydb_topic-codecs
   proto_output
 )

--- a/src/client/topic/impl/CMakeLists.txt
+++ b/src/client/topic/impl/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(client-ydb_topic-impl PUBLIC
   client-ydb_driver
   client-ydb_topic-common
   client-ydb_proto
+  client-ydb_topic
+  client-ydb_topic-codecs
   proto_output
 )
 


### PR DESCRIPTION
1) Обеспечил возможность сборки компилятором GCC, убрав добавление специфичных опций компилятора под условие;
2) Добавил отсутствующие зависимости client-ydb_topic-impl от client-ydb_topic, client-ydb_topic-codecs.

Успешность сборки проверял под Ubuntu-22.04 при помощи GCC-13 и clang-16.