### PR TITLE
fix(cmake): Repair install target and add CI verification

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,3 +118,63 @@ jobs:
       shell: bash
       run: |
         YDB_VERSION=${{ matrix.ydb-version }} ctest -j2 --preset integration
+
+  test-install:
+    name: "Test CMake Install"
+    concurrency:
+      group: test-install-${{ github.ref }}-${{ matrix.compiler }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang, gcc]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        uses: ./.github/actions/prepare_vm
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Restore cache files
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-${{ matrix.compiler }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.compiler }}-
+
+      - name: Build and Install SDK
+        shell: bash
+        run: |
+          mkdir build
+          cmake --preset release-${{ matrix.compiler }} -D YDB_SDK_INSTALL=On
+          cmake --build --preset default
+          cmake --install build --prefix ./_install
+
+      - name: Verify Installation
+        shell: bash
+        run: |
+          echo "Installation directory content for ${{ matrix.compiler }}:"
+          ls -R ./_install
+          if [ -z "$(ls -A ./_install)" ]; then
+            echo "Error: Installation directory is empty!"
+            exit 1
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if (YDB_SDK_INSTALL)
   )
   _ydb_sdk_directory_install(FILES
     ${YDB_SDK_SOURCE_DIR}/cmake/FindBrotli.cmake
-    ${YDB_SDK_SOURCE_DIR}/cmake/FindgRPC.cmake
     ${YDB_SDK_SOURCE_DIR}/cmake/FindIDN.cmake
     ${YDB_SDK_SOURCE_DIR}/cmake/FindLZ4.cmake
     ${YDB_SDK_SOURCE_DIR}/cmake/FindxxHash.cmake

--- a/include/ydb-cpp-sdk/client/iam/common/CMakeLists.txt
+++ b/include/ydb-cpp-sdk/client/iam/common/CMakeLists.txt
@@ -8,4 +8,4 @@ target_link_libraries(client-iam-types
     yutil
 )
 
-_ydb_sdk_install_targets(client-iam-types)
+_ydb_sdk_install_targets(TARGETS client-iam-types)

--- a/include/ydb-cpp-sdk/client/iam_private/common/CMakeLists.txt
+++ b/include/ydb-cpp-sdk/client/iam_private/common/CMakeLists.txt
@@ -5,4 +5,4 @@ target_link_libraries(client-iam_private-types
     client-iam-types
 )
 
-_ydb_sdk_install_targets(client-iam_private-types)
+_ydb_sdk_install_targets(TARGETS client-iam_private-types)

--- a/include/ydb-cpp-sdk/client/topic/CMakeLists.txt
+++ b/include/ydb-cpp-sdk/client/topic/CMakeLists.txt
@@ -25,3 +25,5 @@ generate_enum_serilization(client-ydb_topic-include
   INCLUDE_HEADERS
   include/ydb-cpp-sdk/client/topic/write_events.h
 )
+
+_ydb_sdk_install_targets(TARGETS client-ydb_topic-include)

--- a/src/client/iam_private/common/CMakeLists.txt
+++ b/src/client/iam_private/common/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(client-iam_private-common
     client-iam_private-types
 )
 
-_ydb_sdk_install_targets(client-iam_private-common)
+_ydb_sdk_install_targets(TARGETS client-iam_private-common)

--- a/src/client/types/credentials/CMakeLists.txt
+++ b/src/client/types/credentials/CMakeLists.txt
@@ -16,5 +16,4 @@ target_sources(client-ydb_types-credentials PRIVATE
   credentials.cpp
 )
 
-_ydb_sdk_install_targets(TARGETS client-ydb_types-credentials)
 _ydb_sdk_make_client_component(Credentials client-ydb_types-credentials)


### PR DESCRIPTION
- Fix the `cmake --install` command
- Add a new job to the CI pipeline that verifies the install command works correctly on every pull request

Related to #358