### PR TITLE
Add native-sdk Codecov component

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk), regardless of how each repo tags its uploads.
+#
+# The SDK proper lives in src/ (implementation) and include/ (public headers).
+# The vendored Arcadia libraries (util/, library/, contrib/, third_party/) and
+# examples/tests/tools are not part of the native SDK and are pinned out by listing
+# only the SDK paths.
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK
+      paths:
+        - "src/**"
+        - "include/**"


### PR DESCRIPTION
Adds `codecov.yml` defining a path-based `native-sdk` component scoped to the SDK source: `src/**` (implementation) and `include/**` (public headers). Vendored Arcadia libraries and examples/tests/tools are not part of it.

The `native-sdk` `component_id` is shared across all YDB SDK repos so native-SDK coverage is queryable uniformly via the Codecov API (`?component_id=native-sdk`). The CI upload already scopes coverage to src/include, so the component number equals the current repo-level coverage. Purely additive.