### PR TITLE
Leak CloseInternal session settings to fix use-after-dtor

### DIFF
--- a/src/client/table/impl/table_client.cpp
+++ b/src/client/table/impl/table_client.cpp
@@ -1104,8 +1104,10 @@ TAsyncStatus TTableClient::TImpl::Close(const TKqpSessionCommon* sessionImpl, co
 }
 
 TAsyncStatus TTableClient::TImpl::CloseInternal(const TKqpSessionCommon* sessionImpl) {
-    static const auto internalCloseSessionSettings = TCloseSessionSettings()
-            .ClientTimeout(TDuration::Seconds(2));
+    // // Intentionally leaked to prevent ~TTableClient -> Drain()
+    // to read the destroyed settings at exit.
+    static const auto& internalCloseSessionSettings = *new TCloseSessionSettings(
+        TCloseSessionSettings().ClientTimeout(TDuration::Seconds(2)));
 
     auto driver = Connections_;
     return Close(sessionImpl, internalCloseSessionSettings)


### PR DESCRIPTION
`internalCloseSessionSettings` is a function-local static in `CloseInternal`, so it is constructed on the first session close -- that is, after any static `TTableClient` was constructed. Static destruction runs in reverse order, so the settings are destroyed first, and a later `~TTableClient` ->` Drain()` -> `CloseInternal` at exit reads them after their destructor has run. Immortalize the settings so they outlive every `TTableClient`.