### PR TITLE
Fix macOS CMake build compatibility

### DIFF
--- a/contrib/libs/libc_compat/CMakeLists.txt
+++ b/contrib/libs/libc_compat/CMakeLists.txt
@@ -6,13 +6,18 @@ target_compile_options(contrib-libs-libc_compat PRIVATE
 
 target_sources(contrib-libs-libc_compat PRIVATE
   ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/string.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/explicit_bzero.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/memfd_create.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/strlcat.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/strlcpy.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/reallocarray/reallocarray.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/random/getrandom.c
-  ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/random/getentropy.c
 )
+
+if(NOT APPLE)
+  target_sources(contrib-libs-libc_compat PRIVATE
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/explicit_bzero.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/memfd_create.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/strlcat.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/strlcpy.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/reallocarray/reallocarray.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/random/getrandom.c
+    ${YDB_SDK_SOURCE_DIR}/contrib/libs/libc_compat/random/getentropy.c
+  )
+endif()
 
 _ydb_sdk_install_targets(TARGETS contrib-libs-libc_compat)

--- a/tools/enum_parser/enum_parser/CMakeLists.txt
+++ b/tools/enum_parser/enum_parser/CMakeLists.txt
@@ -27,7 +27,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_link_options(enum_parser PRIVATE
-    -Wl,-platform_version,macos,11.0,11.0
     -framework
     CoreFoundation
   )

--- a/tools/rescompiler/CMakeLists.txt
+++ b/tools/rescompiler/CMakeLists.txt
@@ -27,7 +27,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_link_options(rescompiler PRIVATE
-    -Wl,-platform_version,macos,11.0,11.0
     -framework
     CoreFoundation
   )


### PR DESCRIPTION
## Summary

- use the platform libc implementations on macOS instead of compiling bundled Linux compatibility fallbacks
- remove hard-coded macOS platform-version linker flags from SDK host tools

## Why

The bundled compatibility implementations are intended for platforms that do not provide these libc functions. Compiling them on macOS causes conflicts with the platform libc.

The fixed `platform_version` linker arguments can also disagree with the deployment target selected by CMake or the active toolchain. Removing them leaves deployment-target selection in one place.

Non-Apple builds retain the existing compatibility sources and behavior.

