### PR TITLE
Deprecate TTableClient::StreamExecuteScanQuery in favor of query client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Deprecated `TTableClient::StreamExecuteScanQuery`, use `NQuery::TQueryClient::StreamExecuteQuery` instead.
+
 # v3.22.0
 
 * Added `IWriteSession::Flush` to asynchronously wait until all previously accepted topic writes are acknowledged.

--- a/include/ydb-cpp-sdk/client/table/table.h
+++ b/include/ydb-cpp-sdk/client/table/table.h
@@ -1768,9 +1768,11 @@ public:
     TAsyncReadRowsResult ReadRows(const std::string& table, TValue&& keys, const std::vector<std::string>& columns = {},
         const TReadRowsSettings& settings = TReadRowsSettings());
 
+    [[deprecated("Use NQuery::TQueryClient::StreamExecuteQuery instead")]]
     TAsyncScanQueryPartIterator StreamExecuteScanQuery(const std::string& query,
         const TStreamExecScanQuerySettings& settings = TStreamExecScanQuerySettings());
 
+    [[deprecated("Use NQuery::TQueryClient::StreamExecuteQuery instead")]]
     TAsyncScanQueryPartIterator StreamExecuteScanQuery(const std::string& query, const TParams& params,
         const TStreamExecScanQuerySettings& settings = TStreamExecScanQuerySettings());
 

--- a/tests/integration/basic_example/basic_example.cpp
+++ b/tests/integration/basic_example/basic_example.cpp
@@ -430,7 +430,10 @@ static NYdb::TStatus ScanQuerySelect(TTableClient client, const std::string& pat
         .Build();
 
     // Executes scan query
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     auto resultScanQuery = client.StreamExecuteScanQuery(query, parameters).GetValueSync();
+#pragma GCC diagnostic pop
 
     if (!resultScanQuery.IsSuccess()) {
         return resultScanQuery;


### PR DESCRIPTION
Marks both `TTableClient::StreamExecuteScanQuery` overloads `[[deprecated]]`, pointing to `NQuery::TQueryClient::StreamExecuteQuery`.

The basic_example integration test still exercises the old API, so the deprecation warning is suppressed locally at that call site.